### PR TITLE
starts updating Dockerfiles and metadata to use Condas native env variables

### DIFF
--- a/molssi_hub/compchem/ase322-mamba141/Dockerfile
+++ b/molssi_hub/compchem/ase322-mamba141/Dockerfile
@@ -9,6 +9,6 @@ RUN mamba install numpy \
     ase=3.22.1 \
     -c conda-forge -yq \
  && conda clean -afy \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/compchem/mopac220-mamba141/Dockerfile
+++ b/molssi_hub/compchem/mopac220-mamba141/Dockerfile
@@ -6,6 +6,6 @@ LABEL maintainer="Mohammad Mostafanejad, \
 RUN mamba install mopac==22.0.6 \
     -c conda-forge -yq \
  && mamba clean -afy \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/compchem/mopac220-mamba141/metadata.json
+++ b/molssi_hub/compchem/mopac220-mamba141/metadata.json
@@ -26,9 +26,8 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "USERNAME": "molssi",
-                    "MAMBA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${MAMBA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
             "Volumes": "$(pwd):/home/molssi",

--- a/molssi_hub/general/mamba141/Dockerfile
+++ b/molssi_hub/general/mamba141/Dockerfile
@@ -3,17 +3,16 @@ FROM molssi/debian-bullseye-slim-dev:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-ENV USERNAME molssi
-ENV MAMBA_ROOT_PREFIX /home/${USERNAME}/conda
-ENV PATH ${MAMBA_ROOT_PREFIX}/bin:$PATH
+ENV CONDA_PREFIX /home/molssi/conda
+ENV PATH ${CONDA_PREFIX}/bin:$PATH
 
 RUN wget https://github.com/conda-forge/miniforge/releases/download/23.1.0-1/Mambaforge-23.1.0-1-Linux-$(uname -m).sh \
-    -O /home/${USERNAME}/mambaforge.sh -q \
- && bash /home/${USERNAME}/mambaforge.sh -b -p ${MAMBA_ROOT_PREFIX} \
- && rm /home/${USERNAME}/mambaforge.sh \
- && echo ". ${MAMBA_ROOT_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc \
+    -O /home/molssi/mambaforge.sh -q \
+ && bash /home/molssi/mambaforge.sh -b -p ${CONDA_PREFIX} \
+ && rm /home/molssi/mambaforge.sh \
+ && echo ". ${CONDA_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc \
  && echo "conda activate base" >> ~/.bashrc \
  && conda clean -afy \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/general/mamba141/metadata.json
+++ b/molssi_hub/general/mamba141/metadata.json
@@ -26,9 +26,8 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables":  [
                 {
-                    "USERNAME": "molssi",
-                    "MAMBA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${MAMBA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
             "Volumes": "$(pwd):/home/molssi",


### PR DESCRIPTION
# Summary

This PR updates Dockerfiles and metadata files for Mamba, ASE, and MOPAC to use Conda's build-time environment variables instead of user-defined ones.