### PR TITLE
Adds datamol to machine learning category

### DIFF
--- a/docs/compchem/index.rst
+++ b/docs/compchem/index.rst
@@ -15,7 +15,7 @@ construct and run containerized computational chemistry software.
     ase_example
     mopac220-mamba141
     mopac_example
-    psi4v180-ase322-mamba141
+    psi4v180-mamba141-ase322
     psi4-ase_example
     psi4v180-mamba141
     psi4_example

--- a/docs/compchem/psi4v180-mamba141-ase322.rst
+++ b/docs/compchem/psi4v180-mamba141-ase322.rst
@@ -1,23 +1,23 @@
-.. _psi4v180_ase322_mamba141:
+.. _psi4v180_mamba141_ase322:
 
 *********************************************************
-{{ psi4v180_ase322_mamba141.hub_specifications[0]["Source"].split("/")[-1] }}
+{{ psi4v180_mamba141_ase322.hub_specifications[0]["Source"].split("/")[-1] }}
 *********************************************************
 
-{% set title = psi4v180_ase322_mamba141.get("name") %}
+{% set title = psi4v180_mamba141_ase322.get("name") %}
 
 {{title}}
 =========================================================
 
 {% block content %}
-    {{ psi4v180_ase322_mamba141.description }}
+    {{ psi4v180_mamba141_ase322.description }}
 {% endblock content %}
 
 Source Specifications
 =====================
 
 {% block specifications %}
-    {% for dc in psi4v180_ase322_mamba141.source_specifications %}
+    {% for dc in psi4v180_mamba141_ase322.source_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -28,7 +28,7 @@ MolSSI Container Hub Specifications
 ===================================
 
 {% block hub_specifications %}
-    {% for dc in psi4v180_ase322_mamba141.hub_specifications %}
+    {% for dc in psi4v180_mamba141_ase322.hub_specifications %}
         {% for key, value in dc.items() %}
             * **{{ key }}**: {{ value }}
         {% endfor %}
@@ -39,19 +39,19 @@ MolSSI Container Hub Specifications
 
     .. code-block:: bash
 
-        {{ psi4v180_ase322_mamba141.docker_pull_command }}
+        {{ psi4v180_mamba141_ase322.docker_pull_command }}
 
 * **Container run command**:
 
     .. code-block:: bash
 
-        {{ psi4v180_ase322_mamba141.docker_run_command }}
+        {{ psi4v180_mamba141_ase322.docker_run_command }}
 
 {% block note %}
-{% if psi4v180_ase322_mamba141.note != "" %}
+{% if psi4v180_mamba141_ase322.note != "" %}
 .. note::
 
-        {{ psi4v180_ase322_mamba141.note }}
+        {{ psi4v180_mamba141_ase322.note }}
 {% endif %}
 {% endblock note %}
 
@@ -59,7 +59,7 @@ Image Specifications
 ====================
 
 {% block image_specifications %}
-    {% for dc in psi4v180_ase322_mamba141.image_specifications %}
+    {% for dc in psi4v180_mamba141_ase322.image_specifications %}
         {% for key, value in dc.items() %}
             {% if dc[key] is string or dc[key] == "" %}
                 * **{{ key }}**: {{ value }}

--- a/docs/machine_learning/datamol010-mamba141.rst
+++ b/docs/machine_learning/datamol010-mamba141.rst
@@ -1,0 +1,76 @@
+.. _datamol010_mamba141:
+
+*********************************************************
+{{ datamol010_mamba141.hub_specifications[0]["Source"].split("/")[-1] }}
+*********************************************************
+
+{% set title = datamol010_mamba141.get("name") %}
+
+{{title}}
+=========================================================
+
+{% block content %}
+    {{ datamol010_mamba141.description }}
+{% endblock content %}
+
+Source Specifications
+=====================
+
+{% block specifications %}
+    {% for dc in datamol010_mamba141.source_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock specifications %}
+
+MolSSI Container Hub Specifications
+===================================
+
+{% block hub_specifications %}
+    {% for dc in datamol010_mamba141.hub_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock hub_specifications %}
+
+* **Image pull command**:
+
+    .. code-block:: bash
+
+        {{ datamol010_mamba141.docker_pull_command }}
+
+* **Container run command**:
+
+    .. code-block:: bash
+
+        {{ datamol010_mamba141.docker_run_command }}
+
+{% block note %}
+{% if datamol010_mamba141.note != "" %}
+.. note::
+
+        {{ datamol010_mamba141.note }}
+{% endif %}
+{% endblock note %}
+
+Image Specifications
+====================
+
+{% block image_specifications %}
+    {% for dc in datamol010_mamba141.image_specifications %}
+        {% for key, value in dc.items() %}
+            {% if dc[key] is string or dc[key] == "" %}
+                * **{{ key }}**: {{ value }}
+            {% else %}
+                * **{{ key }}**:
+                {% for key2 in dc[key] %}
+                    {% for key3, val3 in key2.items() %}
+                        + *{{ key3 }}*: {{ val3 }}
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock image_specifications %}

--- a/docs/machine_learning/index.rst
+++ b/docs/machine_learning/index.rst
@@ -12,5 +12,7 @@ covenient and reproducible way.
     :maxdepth: 2
     :titlesonly:
 
-    pytorch201-cu117-mamba141   
+    datamol010-mamba141
+    pytorch201-cu117-mamba141
+    torchani223-mamba141-ase322
     torchani223-mamba141-ase322-jupyter

--- a/molssi_hub/compchem/ase322-mamba141/metadata.json
+++ b/molssi_hub/compchem/ase322-mamba141/metadata.json
@@ -26,9 +26,8 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "USERNAME": "molssi",
-                    "MAMBA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${MAMBA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
             "Volumes": "$(pwd):/home/molssi",

--- a/molssi_hub/compchem/ase322-mamba141/metadata.json
+++ b/molssi_hub/compchem/ase322-mamba141/metadata.json
@@ -26,7 +26,7 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "home/molssi/conda",
+                    "CONDA_PREFIX": "/home/molssi/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],

--- a/molssi_hub/compchem/mopac220-mamba141/metadata.json
+++ b/molssi_hub/compchem/mopac220-mamba141/metadata.json
@@ -26,7 +26,7 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "home/molssi/conda",
+                    "CONDA_PREFIX": "/home/molssi/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],

--- a/molssi_hub/compchem/psi4v180-mamba141-ase322/Dockerfile
+++ b/molssi_hub/compchem/psi4v180-mamba141-ase322/Dockerfile
@@ -3,4 +3,4 @@ FROM molssi/psi4v180-mamba141:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-COPY --from=molssi/ase322-mamba141:latest ${MAMBA_ROOT_PREFIX} ${MAMBA_ROOT_PREFIX}
+COPY --from=molssi/ase322-mamba141:latest ${CONDA_PREFIX} ${CONDA_PREFIX}

--- a/molssi_hub/compchem/psi4v180-mamba141-ase322/metadata.json
+++ b/molssi_hub/compchem/psi4v180-mamba141-ase322/metadata.json
@@ -26,9 +26,8 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "USERNAME": "molssi",
-                    "MAMBA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${MAMBA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
             "Volumes": "$(pwd):/home/molssi",

--- a/molssi_hub/compchem/psi4v180-mamba141/Dockerfile
+++ b/molssi_hub/compchem/psi4v180-mamba141/Dockerfile
@@ -7,6 +7,6 @@ RUN mamba install psi4 \
     -c conda-forge/label/libint_dev \
     -c conda-forge \
  && mamba clean -afy \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${MAMBA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/compchem/psi4v180-mamba141/metadata.json
+++ b/molssi_hub/compchem/psi4v180-mamba141/metadata.json
@@ -26,9 +26,8 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "USERNAME": "molssi",
-                    "MAMBA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${MAMBA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
             "Volumes": "$(pwd):/home/molssi",

--- a/molssi_hub/compchem/psi4v180-mamba141/metadata.json
+++ b/molssi_hub/compchem/psi4v180-mamba141/metadata.json
@@ -26,7 +26,7 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "home/molssi/conda",
+                    "CONDA_PREFIX": "/home/molssi/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],

--- a/molssi_hub/general/mamba141/metadata.json
+++ b/molssi_hub/general/mamba141/metadata.json
@@ -26,7 +26,7 @@
             "Groups (GID)": "molssi (1000)",
             "Environment variables":  [
                 {
-                    "CONDA_PREFIX": "home/molssi/conda",
+                    "CONDA_PREFIX": "/home/molssi/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],

--- a/molssi_hub/machine_learning/datamol010-mamba141/Dockerfile
+++ b/molssi_hub/machine_learning/datamol010-mamba141/Dockerfile
@@ -1,10 +1,9 @@
 FROM molssi/mamba141:latest
- 
+
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-RUN mamba install psi4 \
-    -c conda-forge/label/libint_dev \
+RUN mamba install datamol=0.10.3 \
     -c conda-forge -yq \
  && mamba clean -afy \
  && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \

--- a/molssi_hub/machine_learning/datamol010-mamba141/metadata.json
+++ b/molssi_hub/machine_learning/datamol010-mamba141/metadata.json
@@ -1,0 +1,43 @@
+{
+    "name": "Datamol",
+    "description": "Datamol is a python library to work with molecules. It's a layer built on top of RDKit and aims to be as light as possible.",
+    "source_specifications": [
+        {
+            "Developers": "`Datamol Contributors <https://github.com/datamol-io/datamol/graphs/contributors>`_",
+            "Source": "https://github.com/datamol-io/datamol",
+            "Documentation": "https://docs.datamol.io/stable"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "https://hub.docker.com/r/molssi/datamol010-mamba141",
+            "Tags": "https://hub.docker.com/r/molssi/datamol010-mamba141/tags",
+            "Source":"https://github.com/MolSSI/molssi-hub/tree/main/molssi_hub/machine_learning/datamol010-mamba141",
+            "Recipe":"https://github.com/MolSSI/molssi-hub/blob/main/molssi_hub/machine_learning/datamol010-mamba141/Dockerfile"
+        }
+    ],
+    "docker_pull_command": "docker pull molssi/datamol010-mamba141:latest",
+    "docker_run_command": "docker run -it --name datamol -v $(pwd):/home/molssi molssi/datamol010-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bullseye-slim (linux/amd64)",
+            "Users (UID)": "molssi (1000)",
+            "Groups (GID)": "molssi (1000)",
+            "Environment variables": [
+                {
+                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
+                }
+            ],
+            "Volumes": "$(pwd):/home/molssi",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": "mamba 1.4.1"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Summary

The present PR adds datamol Dockerfile and metadata to the ML category. It also implements quite a few changes and fixes for compatibility with the Hub naming convention and numerous simplifications for using native environment variables in the Dockerfile recipes.