### PR TITLE
Deep modifications to adopt root users with a few new packages added

### DIFF
--- a/docs/compchem/ase_example.rst
+++ b/docs/compchem/ase_example.rst
@@ -57,7 +57,7 @@ paste it into your terminal and edit it to look like the following command line
 
 .. code-block:: bash
 
-    docker run --rm -w /home/molssi/temp -v .:/home/molssi/temp molssi/ase322-mamba141:latest /bin/bash -c "python test.inp"
+    docker run --rm -w /home -v $PWD:/home molssi/ase322-mamba141:latest /bin/bash -c "python test.inp"
 
 then press Enter. 
 
@@ -74,12 +74,6 @@ then press Enter.
     from the host system to the running container by default. For further details see the Apptainer 
     `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
 
-.. caution::
-
-    Ignore (usually many) wanings that you might get the first time a SIF file is being created.
-    This is because of Apptainer's `fakeroot <https://apptainer.org/docs/user/1.1/fakeroot.html>`_ 
-    feature which allows an unprivileged user to run containers as root by default.
-
 If nothing goes wrong, you should see the following lines in your terminal
 
 .. code-block:: bash
@@ -95,7 +89,7 @@ If nothing goes wrong, you should see the following lines in your terminal
 
     .. code-block:: bash
 
-        docker run --rm -w /home/molssi/temp -v .:/home/molssi/temp molssi/ase322-mamba141:latest /bin/bash -c "python test.inp >> test.out"
+        docker run --rm -w /home -v $PWD:/home molssi/ase322-mamba141:latest /bin/bash -c "python test.inp >> test.out"
     
     or
 

--- a/docs/compchem/index.rst
+++ b/docs/compchem/index.rst
@@ -13,11 +13,14 @@ construct and run containerized computational chemistry software.
     
     ase322-mamba141
     ase_example
+    lammps-mamba141
+    lammps_example
+    mendeleev045-mamba141
     mopac220-mamba141
     mopac_example
-    psi4v180-mamba141-ase322
-    psi4-ase_example
     psi4v180-mamba141
     psi4_example
+    psi4v180-mamba141-ase322
+    psi4-ase_example
     pyscf221-mamba141
     pyscf_example

--- a/docs/compchem/lammps-mamba141.rst
+++ b/docs/compchem/lammps-mamba141.rst
@@ -1,0 +1,76 @@
+.. _lammps_mamba141:
+
+*********************************************************
+{{ lammps_mamba141.hub_specifications[0]["Source"].split("/")[-1] }}
+*********************************************************
+
+{% set title = lammps_mamba141.get("name") %}
+
+{{title}}
+=========================================================
+
+{% block content %}
+    {{ lammps_mamba141.description }}
+{% endblock content %}
+
+Source Specifications
+=====================
+
+{% block specifications %}
+    {% for dc in lammps_mamba141.source_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock specifications %}
+
+MolSSI Container Hub Specifications
+===================================
+
+{% block hub_specifications %}
+    {% for dc in lammps_mamba141.hub_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock hub_specifications %}
+
+* **Image pull command**:
+
+    .. code-block:: bash
+
+        {{ lammps_mamba141.docker_pull_command }}
+
+* **Container run command**:
+
+    .. code-block:: bash
+
+        {{ lammps_mamba141.docker_run_command }}
+
+{% block note %}
+{% if lammps_mamba141.note != "" %}
+.. note::
+
+        {{ lammps_mamba141.note }}
+{% endif %}
+{% endblock note %}
+
+Image Specifications
+====================
+
+{% block image_specifications %}
+    {% for dc in lammps_mamba141.image_specifications %}
+        {% for key, value in dc.items() %}
+            {% if dc[key] is string or dc[key] == "" %}
+                * **{{ key }}**: {{ value }}
+            {% else %}
+                * **{{ key }}**:
+                {% for key2 in dc[key] %}
+                    {% for key3, val3 in key2.items() %}
+                        + *{{ key3 }}*: {{ val3 }}
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock image_specifications %}

--- a/docs/compchem/lammps_example.rst
+++ b/docs/compchem/lammps_example.rst
@@ -1,0 +1,114 @@
+.. _lammps_example:
+
+***************
+LAMMPS: Example
+***************
+
+Here, we demonstrate the non-interactive usage of the LAMMPS image recipe.
+
+Running LAMMPS Non-interactively
+================================
+
+First, let's create a temporary folder, ``temp`` in your **home** directory
+and ``cd`` to it
+
+.. code-block:: bash
+
+    mkdir ~/temp && cd ~/temp
+
+Use your favorite text editor to create a new input file. Let's call it **in.lj**
+and copy-paste the following code block into it and then, save it.
+
+.. code-block:: python
+
+    # 1) Initialization
+    units lj
+    dimension 3
+    atom_style atomic
+    pair_style lj/cut 2.5
+    boundary p p p
+
+    # 2) System definition
+    region simulation_box block -20 20 -20 20 -20 20
+    create_box 2 simulation_box
+    create_atoms 1 random 1500 341341 simulation_box
+    create_atoms 2 random 100 127569 simulation_box
+
+    # 3) Simulation settings
+    mass 1 1
+    mass 2 1
+    pair_coeff 1 1 1.0 1.0
+    pair_coeff 2 2 0.5 3.0
+
+    # 4) Visualization
+    thermo 10
+
+    # 5) Run
+    minimize 1.0e-4 1.0e-6 1000 10000
+
+This input file is borrowed from LAMMPS Tutorial 
+`page <https://lammpstutorials.github.io/sphinx/build/html/tutorials/lennardjones.html#the-input-script>`_
+and intends to run a molecular dynamics simulation of a Lennard-Jones
+binary fluid consisting of neutral dots with Langevin thermostat within the NVT ensemble.
+
+At this stage, the content of your directory should look like the following
+
+.. code-block:: bash
+
+    temp
+    └── in.lj
+
+Let's copy the docker run command from the `catalog <https://molssi.github.io/molssi-hub/compchem/lammps-mamba141.html>`_,
+paste it into a terminal and edit it to look like the following command line
+
+.. code-block:: bash
+
+    docker run --rm -w /home -v $(pwd):/home molssi/lammps-mamba141:latest /bin/bash -c "lmp_serial -in in.lj"
+
+then press Enter. If nothing goes wrong, you should see a long list of lines ending in
+
+.. code-block:: bash
+
+    Nlocal:           1600 ave        1600 max        1600 min
+    Histogram: 1 0 0 0 0 0 0 0 0 0
+    Nghost:            756 ave         756 max         756 min
+    Histogram: 1 0 0 0 0 0 0 0 0 0
+    Neighs:           2178 ave        2178 max        2178 min
+    Histogram: 1 0 0 0 0 0 0 0 0 0
+
+    Total # of neighbors = 2178
+    Ave neighs/atom = 1.36125
+    Neighbor list builds = 141
+    Dangerous builds = 1
+    Total wall time: 0:00:00
+
+.. note::
+
+    The same Docker image recipe can also be used with Apptainer (Singularity) to
+    obtain the same result via the following command
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssi/lammps-mamba141:latest lmp_serial -in in.lj
+    
+    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
+    from the host system to the running container by default. For further details see the Apptainer 
+    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
+
+By default, LAMMPS generates a **log.lammps** file with the auto-generated output upon finishing
+the job execution.
+
+.. note::
+
+    You can store the generated output in a separate output file by passing the ``-l <output_name>``
+    to the execution command as follows
+
+    .. code-block:: bash
+
+        docker run --rm -w /home -v $(pwd):/home molssi/lammps-mamba141:latest /bin/bash -c /bin/bash -c "lmp_serial -in in.lj -l log.out"
+    
+    or
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssi/lammps-mamba141:latest lmp_serial -in in.lj -l log.out

--- a/docs/compchem/mendeleev045-mamba141.rst
+++ b/docs/compchem/mendeleev045-mamba141.rst
@@ -1,0 +1,76 @@
+.. _mendeleev045_mamba141:
+
+*********************************************************
+{{ mendeleev045_mamba141.hub_specifications[0]["Source"].split("/")[-1] }}
+*********************************************************
+
+{% set title = mendeleev045_mamba141.get("name") %}
+
+{{title}}
+=========================================================
+
+{% block content %}
+    {{ mendeleev045_mamba141.description }}
+{% endblock content %}
+
+Source Specifications
+=====================
+
+{% block specifications %}
+    {% for dc in mendeleev045_mamba141.source_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock specifications %}
+
+MolSSI Container Hub Specifications
+===================================
+
+{% block hub_specifications %}
+    {% for dc in mendeleev045_mamba141.hub_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock hub_specifications %}
+
+* **Image pull command**:
+
+    .. code-block:: bash
+
+        {{ mendeleev045_mamba141.docker_pull_command }}
+
+* **Container run command**:
+
+    .. code-block:: bash
+
+        {{ mendeleev045_mamba141.docker_run_command }}
+
+{% block note %}
+{% if mendeleev045_mamba141.note != "" %}
+.. note::
+
+        {{ mendeleev045_mamba141.note }}
+{% endif %}
+{% endblock note %}
+
+Image Specifications
+====================
+
+{% block image_specifications %}
+    {% for dc in mendeleev045_mamba141.image_specifications %}
+        {% for key, value in dc.items() %}
+            {% if dc[key] is string or dc[key] == "" %}
+                * **{{ key }}**: {{ value }}
+            {% else %}
+                * **{{ key }}**:
+                {% for key2 in dc[key] %}
+                    {% for key3, val3 in key2.items() %}
+                        + *{{ key3 }}*: {{ val3 }}
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock image_specifications %}

--- a/docs/compchem/mopac_example.rst
+++ b/docs/compchem/mopac_example.rst
@@ -54,30 +54,9 @@ paste it into your terminal and edit it to look like the following command line
 
 .. code-block:: bash
 
-    docker run --rm -w /home/molssi/temp -v $(pwd):/home/molssi/temp molssi/mopac220-mamba141:latest /bin/bash -c "mopac test.mop test.out"
+    docker run --rm -w /home -v $PWD:/home molssi/mopac220-mamba141:latest /bin/bash -c "mopac test.mop test.out"
 
-then press Enter. 
-
-.. note::
-
-    The same Docker image recipe can also be used with Apptainer (Singularity) to
-    obtain the same result via the following command
-
-    .. code-block:: bash
-
-        apptainer exec docker://molssi/mopac220-mamba141:latest mopac test.mop test.out
-    
-    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
-    from the host system to the running container by default. For further details see the Apptainer 
-    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
-
-.. caution::
-
-    Ignore (usually many) wanings that you might get the first time a SIF file is being created.
-    This is because of Apptainer's `fakeroot <https://apptainer.org/docs/user/1.1/fakeroot.html>`_ 
-    feature which allows an unprivileged user to run containers as root by default.
-
-If nothing goes wrong, you should see the following lines in your terminal
+then press Enter. If nothing goes wrong, you should see the following lines in your terminal
 
 .. code-block:: bash
 
@@ -105,3 +84,16 @@ Your directory should now have the following structure
     .. code-block:: bash
 
         * JOB ENDED NORMALLY *
+
+.. note::
+
+    The same Docker image recipe can also be used with Apptainer (Singularity) to
+    obtain the same result via the following command
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssi/mopac220-mamba141:latest mopac test.mop test.out
+    
+    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
+    from the host system to the running container by default. For further details see the Apptainer 
+    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.

--- a/docs/compchem/psi4-ase_example.rst
+++ b/docs/compchem/psi4-ase_example.rst
@@ -52,36 +52,15 @@ At this stage, the content of your directory should look like the following
     └── test.inp
 
 Let's copy the docker run command from the 
-`catalog <https://molssi.github.io/molssi-hub/compchem/psi4v180-ase322-mamba141.html>`_,
+`catalog <https://molssi.github.io/molssi-hub/compchem/psi4v180-mamba141-ase322.html>`_,
 paste it into your terminal and edit it to look like the following command line
 
 
 .. code-block:: bash
 
-    docker run --rm -w /home/molssi/temp -v $(pwd):/home/molssi/temp molssi/psi4v180-ase322-mamba141:latest /bin/bash -c "python test.inp"
+    docker run --rm -w /home -v $(pwd):/home molssi/psi4v180-mamba141-ase322:latest /bin/bash -c "python test.inp"
 
-then press Enter. 
-
-.. note::
-
-    The same Docker image recipe can also be used with Apptainer (Singularity) to
-    obtain the same result via the following command
-
-    .. code-block:: bash
-
-        apptainer exec docker://molssi/psi4v180-ase322-mamba141:latest python test.inp
-    
-    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
-    from the host system to the running container by default. For further details see the Apptainer 
-    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
-
-.. caution::
-
-    Ignore (usually many) wanings that you might get the first time a SIF file is being created.
-    This is because of Apptainer's `fakeroot <https://apptainer.org/docs/user/1.1/fakeroot.html>`_ 
-    feature which allows an unprivileged user to run containers as root by default.
-
-If nothing goes wrong, you should see the following lines in your terminal
+then press Enter. If nothing goes wrong, you should see the following lines in your terminal
 
 .. code-block:: bash
 
@@ -100,18 +79,31 @@ The harmonic vibrational frequencies are shown in the final output line.
 
 .. note::
 
+    The same Docker image recipe can also be used with Apptainer (Singularity) to
+    obtain the same result via the following command
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssi/psi4v180-mamba141-ase322:latest python test.inp
+    
+    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
+    from the host system to the running container by default. For further details see the Apptainer 
+    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
+
+.. note::
+
     You can store the generated output in a separate output file by changing the command as
     follows
 
     .. code-block:: bash
 
-        docker run --rm -w /home/molssi/temp -v $(pwd):/home/molssi/temp molssi/psi4v180-ase322-mamba141:latest /bin/bash -c "python test.inp >> test.out"
+        docker run --rm -w /home -v $(pwd):/home molssi/psi4v180-mamba141-ase322:latest /bin/bash -c "python test.inp >> test.out"
     
     or
 
     .. code-block:: bash
 
-        apptainer exec docker://molssi/psi4v180-ase322-mamba141:latest python test.inp >> test.out
+        apptainer exec docker://molssi/psi4v180-mamba141-ase322:latest python test.inp >> test.out
 
 .. caution::
 
@@ -123,14 +115,14 @@ The harmonic vibrational frequencies are shown in the final output line.
 
     .. code-block:: bash
 
-        docker run --rm -w /home/molssi/temp -v $(pwd):/home/molssi/temp molssi/psi4v180-ase322-mamba141:latest /bin/bash -c "export PSI_SCRATCH=/home/molssi/temp && python test.inp >> test.out"
+        docker run --rm -w /home -v $(pwd):/home molssi/psi4v180-mamba141-ase322:latest /bin/bash -c "export PSI_SCRATCH=/home && python test.inp >> test.out"
     
     or
 
     .. code-block:: bash
 
-        apptainer exec docker://molssi/psi4v180-ase322-mamba141:latest sh -c "export PSI_SCRATCH=$PWD && python test.inp >> test.out"
+        apptainer exec docker://molssi/psi4v180-mamba141-ase322:latest /bin/sh -c "export PSI_SCRATCH=$PWD && python test.inp >> test.out"
 
-    Since our current working directory on the host machine is binded to ``/home/molssi`` within the container,
-    the contents of the ``PSI_SCRATCH`` will be retained even after the container is destroyed when the 
-    job is finished.
+    Since our current working directory on the host machine is binded to ``/home`` within 
+    the container, the contents of the ``PSI_SCRATCH`` will be retained even after the container is 
+    destroyed when the job is finished.

--- a/docs/compchem/psi4_example.rst
+++ b/docs/compchem/psi4_example.rst
@@ -49,30 +49,9 @@ paste it into your terminal and edit it to look like the following command line
 
 .. code-block:: bash
 
-    docker run -w /home/molssi/temp -v $(pwd):/home/molssi/temp --rm molssi/psi4v180-mamba141:latest /bin/bash -c "psi4 test.inp"
+    docker run --rm -w /home -v $(pwd):/home molssi/psi4v180-mamba141:latest /bin/bash -c "psi4 test.inp"
 
-then press Enter. 
-
-.. note::
-
-    The same Docker image recipe can also be used with Apptainer (Singularity) to
-    obtain the same result via the following command
-
-    .. code-block:: bash
-
-        apptainer exec docker://molssi/psi4v180-mamba141:latest psi4 test.inp
-    
-    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
-    from the host system to the running container by default. For further details see the Apptainer 
-    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
-
-.. caution::
-
-    Ignore (usually many) wanings that you might get the first time a SIF file is being created.
-    This is because of Apptainer's `fakeroot <https://apptainer.org/docs/user/1.1/fakeroot.html>`_ 
-    feature which allows an unprivileged user to run containers as root by default.
-
-If nothing goes wrong, you should see the following lines in your terminal
+then press Enter. If nothing goes wrong, you should see the following lines in your terminal
 
 .. code-block:: bash
 
@@ -89,7 +68,6 @@ Your directory should now have the following structure
     ├── test.out
     └── timer.dat
 
-
 .. note::
 
     If you're a pessimist, run the following command to see if the job has finished normally
@@ -103,3 +81,16 @@ Your directory should now have the following structure
     .. code-block:: bash
 
         *** Psi4 exiting successfully. Buy a developer a beer!
+
+.. note::
+
+    The same Docker image recipe can also be used with Apptainer (Singularity) to
+    obtain the same result via the following command
+
+    .. code-block:: bash
+
+        apptainer exec docker://molssi/psi4v180-mamba141:latest psi4 test.inp
+    
+    Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
+    from the host system to the running container by default. For further details see the Apptainer 
+    `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.

--- a/docs/compchem/pyscf_example.rst
+++ b/docs/compchem/pyscf_example.rst
@@ -38,15 +38,20 @@ At this stage, the content of your directory should look like the following
     └── test.inp
 
 It's time to copy the docker run command from the 
-`catalog <https://molssi-ai.github.io/molssi-ai-hub/compchem/pyscf221-base-mamba141-jupyter.html>`_,
+`catalog <https://molssi.github.io/molssi-hub/compchem/pyscf221-mamba141.html>`_,
 paste it into your terminal and edit it to look like the following command line
 
 
 .. code-block:: bash
 
-    docker run --rm -v $(pwd):/home molssiai/pyscf221-base-mamba141-jupyter:5.15.2023 /bin/bash -c "python /home/test.inp"
+    docker run --rm -w /home -v $(pwd):/home molssi/pyscf221-mamba141:latest /bin/bash -c "python test.inp"
 
-then press Enter. 
+then press Enter. Running the aforementioned command should generate the following
+output in your terminal
+
+.. code-block:: bash
+
+    converged SCF energy = -74.9611711378677
 
 .. note::
 
@@ -55,17 +60,11 @@ then press Enter.
 
     .. code-block:: bash
 
-        apptainer exec docker://molssiai/pyscf221-base-mamba141-jupyter:5.15.2023 python test.inp
+        apptainer exec docker://molssi/pyscf221-mamba141:latest python test.inp
     
     Note that Apptainer binds ``/home/$USER``, ``/tmp`` and current working directory (``$PWD``)
     from the host system to the running container by default. For further details see the Apptainer 
     `documentation <https://apptainer.org/docs/user/latest/quick_start.html#working-with-files>`_.
-
-Running the aforementioned command should generate the following output in your terminal
-
-.. code-block:: bash
-
-    converged SCF energy = -74.9611711378677
 
 .. note::
 
@@ -74,10 +73,10 @@ Running the aforementioned command should generate the following output in your 
 
     .. code-block:: bash
 
-        docker run --rm -v $(pwd):/home molssiai/pyscf221-base-mamba141-jupyter:5.15.2023 /bin/bash -c "python /home/test.inp >> /home/test.out"
+        docker run --rm -w /home -v $(pwd):/home molssi/pyscf221-mamba141:latest /bin/bash -c "python test.inp >> test.out"
     
     or
 
     .. code-block:: bash
 
-        apptainer exec docker://molssiai/pyscf221-base-mamba141-jupyter:5.15.2023 python test.inp >> test.out
+        apptainer exec docker://molssi/pyscf221-mamba141:latest python test.inp >> test.out

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,7 +143,7 @@ html_theme_options = {
     "molssi_dark": "molssi_main_logo_inverted_white.png",
     },
     "show_toc_level": 2,
-    "header_links_before_dropdown": 4,
+    "header_links_before_dropdown": 6,
     "external_links": [
     {"name": "MolSSI", "url": "https://molssi.org"}
 ],

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,8 +1,44 @@
 .. _installation:
 
-***********************
-Build the Documentation
-***********************
+*************
+Installations
+*************
+
+Upon installing Docker or Apptainer on your machine,
+you will be able to use any containerized software listed 
+in the MolSSI Container Hub. Simply, follow the instructions
+below and navigate to the :ref:`quick_start` page for further
+instructions on how to unleash the power of containerized
+software in your research and hopefully, boost your productivity.
+
+Docker 
+======
+
+Users have two options to install Docker on their machines
+to be able to use the containerized software in **MolSSI Container Hub**:
+`Docker Desktop <https://docs.docker.com/desktop>`_ and 
+`Docker Engine <https://docs.docker.com/engine>`_. Docker Desktop is 
+the user-friendly option with a nice graphical user interface. It also
+comes from multiple Docker packages including Docker Engine. So, if you
+choose to install the Docker Desktop on your system, you should not install
+the Docker Engine as well. Users who are comfortable interacting with the 
+Docker daemon directly through the command-line interface can install Docker
+Engine on their system.
+
+Apptainer (Singularity)
+=======================
+
+Docker image recipes can also be used with 
+`Apptainer <https://apptainer.org/docs/admin/1.1/installation.html>`_. 
+Apptainer is an option that comes in handy for non-root users. This is 
+a common scenario on supercomputing clusters where users often do not have 
+sudo privileges.
+
+Building the Documentation
+==========================
+
+The following section is useful for users who want to build the documentation locally
+on their machine. If you do not need it, simply skip this section.
 
 .. tip::
 

--- a/molssi_hub/base/debian-bullseye-slim-dev/Dockerfile
+++ b/molssi_hub/base/debian-bullseye-slim-dev/Dockerfile
@@ -5,12 +5,6 @@ LABEL maintainer="Mohammad Mostafanejad, \
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-# Setting the default user
-# Change by passing -e USERNAME=XXXX in 'docker run ...'
-ARG USERNAME=molssi
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
 RUN apt-get update -q \
  && apt-get install -q -y --no-install-recommends \
         ca-certificates \
@@ -24,15 +18,5 @@ RUN apt-get update -q \
         procps \
         wget \
         vim \
-        sudo \
-# Creating the user
- && groupadd --gid $USER_GID $USERNAME \
- && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-# Adding sudo support. Omit if you don't need to install software after connecting.
- && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
- && chmod 0440 /etc/sudoers.d/$USERNAME \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-# Setting the default user. Omit if you want to keep the default as root.
-USER $USERNAME

--- a/molssi_hub/base/debian-bullseye-slim-dev/metadata.json
+++ b/molssi_hub/base/debian-bullseye-slim-dev/metadata.json
@@ -21,11 +21,11 @@
     "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
-            "OS/Arch": "debian:bullseye-slim",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/386, linux/mips64le, linux/ppc64le, linux/s390x)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": "None",
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": "None"
         }

--- a/molssi_hub/compchem/ase322-mamba141/metadata.json
+++ b/molssi_hub/compchem/ase322-mamba141/metadata.json
@@ -17,20 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/ase322-mamba141:latest",
-    "docker_run_command": "docker run -it --name ase -v $(pwd):/home/molssi molssi/ase322-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name ase -v $(pwd):/home molssi/ase322-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/compchem/lammps-mamba141/Dockerfile
+++ b/molssi_hub/compchem/lammps-mamba141/Dockerfile
@@ -1,0 +1,11 @@
+FROM molssi/mamba141:latest
+ 
+LABEL maintainer="Mohammad Mostafanejad, \
+                  Molecular Sciences Software Institute"
+
+RUN mamba install lammps=2023.03.28 \
+    -c conda-forge -yq \
+ && mamba clean -afy \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/compchem/lammps-mamba141/metadata.json
+++ b/molssi_hub/compchem/lammps-mamba141/metadata.json
@@ -1,0 +1,43 @@
+{
+    "name": "LAMMPS",
+    "description": "LAMMPS stands for Large-scale Atomic/Molecular Massively Parallel Simulator. LAMMPS is a classical molecular dynamics simulation code focusing on materials modeling. It was designed to run efficiently on parallel computers and to be easy to extend and modify. Originally developed at Sandia National Laboratories, a US Department of Energy facility, LAMMPS now includes contributions from many research groups and individuals from many institutions. Most of the funding for LAMMPS has come from the US Department of Energy (DOE). LAMMPS is open-source software distributed under the terms of the GNU Public License Version 2 (GPLv2).",
+    "source_specifications": [
+        {
+            "Developers": "`LAMMPS Authors <https://www.lammps.org/authors.html>`_",
+            "Source": "https://github.com/lammps/lammps",
+            "Documentation": "https://docs.lammps.org/Manual.html"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "https://hub.docker.com/r/molssi/lammps-mamba141",
+            "Tags": "https://hub.docker.com/r/molssi/lammps-mamba141/tags",
+            "Source":"https://github.com/MolSSI/molssi-hub/tree/main/molssi_hub/compchem/lammps-mamba141",
+            "Recipe":"https://github.com/MolSSI/molssi-hub/blob/main/molssi_hub/compchem/lammps-mamba141/Dockerfile"
+        }
+    ],
+    "docker_pull_command": "docker pull molssi/lammps-mamba141:latest",
+    "docker_run_command": "docker run -it --name lammps -v $(pwd):/home molssi/lammps-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bullseye-slim (linux/amd64)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
+            "Environment variables":  [
+                {
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"                
+                }
+            ],
+            "Volumes": "None",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": "mamba 1.4.1"
+                }
+            ]
+        }
+    ]
+}

--- a/molssi_hub/compchem/mendeleev045-mamba141/Dockerfile
+++ b/molssi_hub/compchem/mendeleev045-mamba141/Dockerfile
@@ -1,0 +1,11 @@
+FROM molssi/mamba141:latest
+
+LABEL maintainer="Mohammad Mostafanejad, \
+                  Molecular Sciences Software Institute"
+
+RUN mamba install mendeleev=0.4.5 \
+    -c lmmentel -yq \
+ && mamba clean -afy \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/compchem/mendeleev045-mamba141/metadata.json
+++ b/molssi_hub/compchem/mendeleev045-mamba141/metadata.json
@@ -1,0 +1,43 @@
+{
+    "name": "mendeleev",
+    "description": "A python package for accessing various properties of elements, ions and isotopes in the periodic table of elements.",
+    "source_specifications": [
+        {
+            "Developers": "`Mendeleev Contributors <https://github.com/lmmentel/mendeleev/graphs/contributors>`_",
+            "Source": "https://github.com/lmmentel/mendeleev",
+            "Documentation": "https://mendeleev.readthedocs.io/en/stable/index.html"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "https://hub.docker.com/r/molssi/mendeleev045-mamba141",
+            "Tags": "https://hub.docker.com/r/molssi/mendeleev045-mamba141/tags",
+            "Source":"https://github.com/molssi/molssi-hub/tree/main/molssi_hub/compchem/mendeleev045-mamba141",
+            "Recipe":"https://github.com/molssi/molssi-hub/blob/main/molssi_hub/compchem/mendeleev045-mamba141/Dockerfile"
+        }
+    ],
+    "docker_pull_command": "docker pull molssi/mendeleev045-mamba141:latest",
+    "docker_run_command": "docker run -it --name mendeleev -v $(pwd):/home molssi/mendeleev045-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
+            "Environment variables": [
+                {
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
+                }
+            ],
+            "Volumes": "None",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": "mamba 1.4.1"
+                }
+            ]
+        }
+    ]
+}

--- a/molssi_hub/compchem/mopac220-mamba141/metadata.json
+++ b/molssi_hub/compchem/mopac220-mamba141/metadata.json
@@ -10,27 +10,27 @@
     ],
     "hub_specifications": [
         {
-            "Repository": "https://hub.docker.com/repository/docker/molssi/mopac220-mamba141/general",
-            "Tags": "https://hub.docker.com/repository/docker/molssi/mopac220-mamba141/tags",
+            "Repository": "https://hub.docker.com/r/molssi/mopac220-mamba141/general",
+            "Tags": "https://hub.docker.com/r/molssi/mopac220-mamba141/tags",
             "Source":"https://github.com/molssi/molssi-hub/tree/main/molssi_hub/compchem/mopac220-mamba141",
             "Recipe":"https://github.com/molssi/molssi-hub/tree/main/molssi_hub/compchem/mopac220-mamba141/Dockerfile"
         }
     ],
     "docker_pull_command": "docker pull molssi/mopac220-mamba141:latest",
-    "docker_run_command": "docker run -it --name mopac -v $(pwd):/home/molssi molssi/mopac220-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name mopac -v $(pwd):/home molssi/mopac220-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/compchem/psi4v180-mamba141-ase322/metadata.json
+++ b/molssi_hub/compchem/psi4v180-mamba141-ase322/metadata.json
@@ -10,27 +10,27 @@
     ],
     "hub_specifications": [
         {
-            "Repository": "https://hub.docker.com/r/molssi/psi4v180-ase322-mamba141",
-            "Tags": "https://hub.docker.com/r/molssi/psi4v180-ase322-mamba141/tags",
-            "Source":"https://github.com/molssi/molssi-hub/tree/main/molssi_hub/compchem/psi4v180-ase322-mamba141",
-            "Recipe":"https://github.com/molssi/molssi-hub/blob/main/molssi_hub/compchem/psi4v180-ase322-mamba141/Dockerfile"
+            "Repository": "https://hub.docker.com/r/molssi/psi4v180-mamba141-ase322",
+            "Tags": "https://hub.docker.com/r/molssi/psi4v180-mamba141-ase322/tags",
+            "Source":"https://github.com/molssi/molssi-hub/tree/main/molssi_hub/compchem/psi4v180-mamba141-ase322",
+            "Recipe":"https://github.com/molssi/molssi-hub/blob/main/molssi_hub/compchem/psi4v180-mamba141-ase322/Dockerfile"
         }
     ],
-    "docker_pull_command": "docker pull molssi/psi4v180-ase322-mamba141:latest",
-    "docker_run_command": "docker run -it --name psi4-ase -v $(pwd):/home/molssi molssi/psi4v180-ase322-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_pull_command": "docker pull molssi/psi4v180-mamba141-ase322:latest",
+    "docker_run_command": "docker run -it --name psi4-ase -v $(pwd):/home molssi/psi4v180-mamba141-ase322:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/compchem/psi4v180-mamba141/Dockerfile
+++ b/molssi_hub/compchem/psi4v180-mamba141/Dockerfile
@@ -3,7 +3,8 @@ FROM molssi/mamba141:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-RUN mamba install psi4 \
+RUN mamba install psi4 \ 
+    python=3.8 \
     -c conda-forge/label/libint_dev \
     -c conda-forge -yq \
  && mamba clean -afy \

--- a/molssi_hub/compchem/psi4v180-mamba141/metadata.json
+++ b/molssi_hub/compchem/psi4v180-mamba141/metadata.json
@@ -17,20 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/psi4v180-mamba141:latest",
-    "docker_run_command": "docker run -it --name psi4 -v $(pwd):/home/molssi molssi/psi4v180-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name psi4 -v $(pwd):/home molssi/psi4v180-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/compchem/pyscf221-mamba141/metadata.json
+++ b/molssi_hub/compchem/pyscf221-mamba141/metadata.json
@@ -17,20 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/pyscf221-mamba141:latest",
-    "docker_run_command": "docker run -it --name pyscf -v $(pwd):/home/molssi molssi/pyscf221-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name pyscf -v $(pwd):/home molssi/pyscf221-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables": [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/general/mamba141/Dockerfile
+++ b/molssi_hub/general/mamba141/Dockerfile
@@ -3,16 +3,14 @@ FROM molssi/debian-bullseye-slim-dev:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-ENV CONDA_PREFIX /home/molssi/conda
+ENV CONDA_PREFIX /opt/conda
 ENV PATH ${CONDA_PREFIX}/bin:$PATH
 
-RUN wget https://github.com/conda-forge/miniforge/releases/download/23.1.0-1/Mambaforge-23.1.0-1-Linux-$(uname -m).sh \
-    -O /home/molssi/mambaforge.sh -q \
- && bash /home/molssi/mambaforge.sh -b -p ${CONDA_PREFIX} \
- && rm /home/molssi/mambaforge.sh \
- && echo ". ${CONDA_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc \
- && echo "conda activate base" >> ~/.bashrc \
- && conda clean -afy \
+COPY --from=condaforge/mambaforge ${CONDA_PREFIX} ${CONDA_PREFIX}
+
+RUN echo ". ${CONDA_PREFIX}/etc/profile.d/conda.sh" >> $HOME/.bashrc \
+ && echo "conda activate base" >> $HOME/.bashrc \
+ && mamba clean -ay \
  && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
  && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
  && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/general/mamba141/metadata.json
+++ b/molssi_hub/general/mamba141/metadata.json
@@ -17,20 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/mamba141:latest",
-    "docker_run_command": "docker run -it --name mamba  -v $(pwd):/home/molssi molssi/mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name mamba  -v $(pwd):/home molssi/mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/general/micromamba142-py310/Dockerfile
+++ b/molssi_hub/general/micromamba142-py310/Dockerfile
@@ -4,13 +4,15 @@ LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
 ENV MAMBA_EXE /bin/micromamba
-ENV MAMBA_ROOT_PREFIX /home/molssi/micromamba
+ENV MAMBA_ROOT_PREFIX /opt/micromamba
+# Added for compatibility with consumer images
+ENV CONDA_PREFIX ${MAMBA_ROOT_PREFIX}
 
-COPY --from=mambaorg/micromamba:1.4.2 /bin/micromamba ${MAMBA_EXE}
+COPY --from=mambaorg/micromamba:1.4.2 ${MAMBA_EXE} ${MAMBA_EXE}
 
 RUN micromamba shell init --shell=bash --prefix=${MAMBA_ROOT_PREFIX} \
- && echo ". ${MAMBA_ROOT_PREFIX}/etc/profile.d/micromamba.sh" >> ~/.bashrc \
- && echo "micromamba activate base" >> ~/.bashrc \
+ && echo ". ${MAMBA_ROOT_PREFIX}/etc/profile.d/micromamba.sh" >> $HOME/.bashrc \
+ && echo "micromamba activate base" >> $HOME/.bashrc \
  && micromamba install -n base python=3.10 \
     -c conda-forge -y \
  && micromamba clean -afy \

--- a/molssi_hub/general/micromamba142-py310/metadata.json
+++ b/molssi_hub/general/micromamba142-py310/metadata.json
@@ -17,20 +17,21 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/micromamba142-py310:latest",
-    "docker_run_command": "docker run -it --name micromamba -v $(pwd):/home/molssi molssi/micromamba142-py310:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name micromamba -v $(pwd):/home molssi/micromamba142-py310:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
                     "MAMBA_EXE": "/bin/micromamba",
-                    "MAMBA_ROOT_PREFIX": "/home/molssi/micromamba"
+                    "MAMBA_ROOT_PREFIX": "/opt/micromamba",
+                    "CONDA_PREFIX": "${MAMBA_ROOT_PREFIX}"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/general/miniconda3/Dockerfile
+++ b/molssi_hub/general/miniconda3/Dockerfile
@@ -3,17 +3,16 @@ FROM molssi/debian-bullseye-slim-dev:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-ENV USERNAME molssi
-ENV CONDA_ROOT_PREFIX home/${USERNAME}/conda
-ENV PATH ${CONDA_ROOT_PREFIX}/bin:$PATH
+ENV CONDA_PREFIX /opt/conda
+ENV PATH ${CONDA_PREFIX}/bin:$PATH
 
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-py310_23.3.1-0-Linux-$(uname -m).sh \
-    -O /home/${USERNAME}/miniconda.sh -q \
- && bash /home/${USERNAME}/miniconda.sh -b -p ${CONDA_ROOT_PREFIX} \
- && rm /home/${USERNAME}/miniconda.sh \
- && echo ". ${CONDA_ROOT_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc \
+    -O $HOME/miniconda.sh -q \
+ && bash $HOME/miniconda.sh -b -p ${CONDA_PREFIX} \
+ && rm $HOME/miniconda.sh \
+ && echo ". ${CONDA_PREFIX}/etc/profile.d/conda.sh" >> ~/.bashrc \
  && echo "conda activate base" >> ~/.bashrc \
  && conda clean -afy \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/general/miniconda3/metadata.json
+++ b/molssi_hub/general/miniconda3/metadata.json
@@ -17,21 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/miniconda3:latest",
-    "docker_run_command": "docker run -it --name miniconda3 -v $(pwd):/home/molssi molssi/miniconda3:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name miniconda3 -v $(pwd):/home molssi/miniconda3:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64, linux/arm64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
-                    "USERNAME": "molssi",
-                    "CONDA_ROOT_PREFIX": "home/${USERNAME}/conda",
-                    "PATH": "${CONDA_ROOT_PREFIX}/bin:$PATH"
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/machine_learning/datamol010-mamba141/metadata.json
+++ b/molssi_hub/machine_learning/datamol010-mamba141/metadata.json
@@ -17,20 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/datamol010-mamba141:latest",
-    "docker_run_command": "docker run -it --name datamol -v $(pwd):/home/molssi molssi/datamol010-mamba141:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home/molssi`` option mounts the current working directory to ``/home/molssi`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_run_command": "docker run -it --name datamol -v $(pwd):/home molssi/datamol010-mamba141:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
-            "Environment variables": [
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
+            "Environment variables":  [
                 {
-                    "CONDA_PREFIX": "/home/molssi/conda",
+                    "CONDA_PREFIX": "/opt/conda",
                     "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/machine_learning/pytorch201-cu117-mamba141/Dockerfile
+++ b/molssi_hub/machine_learning/pytorch201-cu117-mamba141/Dockerfile
@@ -3,15 +3,13 @@ FROM molssi/mamba141:latest
 LABEL maintainer="Mohammad Mostafanejad, \
                   Molecular Sciences Software Institute"
 
-ENV CONDA_ROOT_PREFIX /home/molssi/conda
-
-RUN mamba install pytorch==2.0.1 \
+RUN mamba install pytorch=2.0.1 \
     torchvision=0.15.2 \
     torchaudio=2.0.2 \
-    pytorch-cuda=11.7 \
+    pytorch-cuda \
     -c pytorch \
     -c nvidia -yq \
  && mamba clean -afy \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/machine_learning/pytorch201-cu117-mamba141/metadata.json
+++ b/molssi_hub/machine_learning/pytorch201-cu117-mamba141/metadata.json
@@ -22,15 +22,15 @@
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
-
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
-                    "CONDA_ROOT_PREFIX": "/home/molssi/conda"
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/machine_learning/torchani223-mamba141-ase322-jupyter/Dockerfile
+++ b/molssi_hub/machine_learning/torchani223-mamba141-ase322-jupyter/Dockerfile
@@ -7,6 +7,20 @@ RUN mamba install numpy \
     scipy \
     matplotlib \
     ase=3.22.1 \
-    -c conda-forge -yq \
+    jupyterlab \
+    -c conda-forge -y \
  && pip install --no-cache-dir torchani==2.2.3 \
- && conda clean -afy
+ && conda clean -afy \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete
+
+CMD [ \
+     "jupyter", \
+     "lab", \
+     "--notebook-dir=/home", \
+     "--no-browser", \
+     "--allow-root", \
+     "--ip=*", \
+     "--port=8888" \
+    ]

--- a/molssi_hub/machine_learning/torchani223-mamba141-ase322-jupyter/metadata.json
+++ b/molssi_hub/machine_learning/torchani223-mamba141-ase322-jupyter/metadata.json
@@ -17,19 +17,20 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/torchani223-cu117-ase-mamba141-jupyter:5.3.2023",
-    "docker_run_command": "docker run -it --name torchani -v $(pwd):/home molssi/torchani223-cu117-ase-mamba141-jupyter:5.3.2023 /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option. For NVIDIA GPU support with nvidia containers, add the ``--runtime nvidia --gpus all`` flags to the previous container run command and then run ``nvidia-smi`` to make sure all available GPUs on the docker host are visible inside the docker container.",
+    "docker_run_command": "docker run -it --name torchani -v $(pwd):/home -p 8888:8888 molssi/torchani223-cu117-ase-mamba141-jupyter:5.3.2023",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option. By default, Jupyter server communicates to your computed through port ``8888``. Make sure to include ``-p 8888:8888`` in the ``docker run`` command. For NVIDIA GPU support with nvidia containers, add the ``--runtime nvidia --gpus all`` flags to the previous container run command and then run ``nvidia-smi`` to make sure all available GPUs on the docker host are visible inside the docker container.",
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
-                    "PATH":"/opt/conda/bin"
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):$HOME",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {

--- a/molssi_hub/machine_learning/torchani223-mamba141-ase322/Dockerfile
+++ b/molssi_hub/machine_learning/torchani223-mamba141-ase322/Dockerfile
@@ -6,10 +6,10 @@ LABEL maintainer="Mohammad Mostafanejad, \
 RUN mamba install numpy \
     scipy \
     matplotlib \
-    ase \
+    ase=3.22.1 \
     -c conda-forge -yq \
  && pip install --no-cache-dir torchani==2.2.3 \
  && conda clean -afy \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.a' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.pyc' -delete \
- && find ${CONDA_ROOT_PREFIX} -follow -type f -name '*.js.map' -delete
+ && find ${CONDA_PREFIX} -follow -type f -name '*.a' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.pyc' -delete \
+ && find ${CONDA_PREFIX} -follow -type f -name '*.js.map' -delete

--- a/molssi_hub/machine_learning/torchani223-mamba141-ase322/metadata.json
+++ b/molssi_hub/machine_learning/torchani223-mamba141-ase322/metadata.json
@@ -22,14 +22,15 @@
     "image_specifications":[
         {
             "OS/Arch": "debian:bullseye-slim (linux/amd64)",
-            "Users (UID)": "molssi (1000)",
-            "Groups (GID)": "molssi (1000)",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
             "Environment variables":  [
                 {
-                    "PATH":"/opt/conda/bin"
+                    "CONDA_PREFIX": "/opt/conda",
+                    "PATH": "${CONDA_PREFIX}/bin:$PATH"
                 }
             ],
-            "Volumes": "$(pwd):/home/molssi",
+            "Volumes": "None",
             "Network": "None",
             "Extras": [
                 {


### PR DESCRIPTION
# Summary

The present PR adds a few new image recipes for packages such as _mendeleev_, _datamol_ and _lammps_. It also removes the default non-root user from all image recipes in favor of using root (UID/GID = 0) in order to avoid the mounted drive permission nightmare at the cost of security exposure. See [here](https://github.com/moby/moby/issues/2259) for a decade-long debate over this issue.