### PR TITLE
Add recipe and documentation for RDKit Postgres image

### DIFF
--- a/docs/compchem/index.rst
+++ b/docs/compchem/index.rst
@@ -25,3 +25,5 @@ construct and run containerized computational chemistry software.
     psi4-ase_example
     pyscf221-mamba141
     pyscf_example
+    rdkit-postgres162
+    rdkitpostgres-example

--- a/docs/compchem/rdkit-postgres162.rst
+++ b/docs/compchem/rdkit-postgres162.rst
@@ -1,0 +1,76 @@
+.. _rdkit_postgres162:
+
+*********************************************************
+{{ rdkit_postgres162.hub_specifications[0]["Source"].split("/")[-1] }}
+*********************************************************
+
+{% set title = rdkit_postgres162.get("name") %}
+
+{{title}}
+=========================================================
+
+{% block content %}
+    {{ rdkit_postgres162.description }}
+{% endblock content %}
+
+Source Specifications
+=====================
+
+{% block specifications %}
+    {% for dc in rdkit_postgres162.source_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock specifications %}
+
+MolSSI Container Hub Specifications
+===================================
+
+{% block hub_specifications %}
+    {% for dc in rdkit_postgres162.hub_specifications %}
+        {% for key, value in dc.items() %}
+            * **{{ key }}**: {{ value }}
+        {% endfor %}
+    {% endfor %}
+{% endblock hub_specifications %}
+
+* **Image pull command**:
+
+    .. code-block:: bash
+
+        {{ rdkit_postgres162.docker_pull_command }}
+
+* **Container run command**:
+
+    .. code-block:: bash
+
+        {{ rdkit_postgres162.docker_run_command }}
+
+{% block note %}
+{% if rdkit_postgres162.note != "" %}
+.. note::
+
+        {{ rdkit_postgres162.note }}
+{% endif %}
+{% endblock note %}
+
+Image Specifications
+====================
+
+{% block image_specifications %}
+    {% for dc in rdkit_postgres162.image_specifications %}
+        {% for key, value in dc.items() %}
+            {% if dc[key] is string or dc[key] == "" %}
+                * **{{ key }}**: {{ value }}
+            {% else %}
+                * **{{ key }}**:
+                {% for key2 in dc[key] %}
+                    {% for key3, val3 in key2.items() %}
+                        + *{{ key3 }}*: {{ val3 }}
+                    {% endfor %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+{% endblock image_specifications %}

--- a/docs/compchem/rdkitpostgres-example.rst
+++ b/docs/compchem/rdkitpostgres-example.rst
@@ -3,3 +3,80 @@
 ********************************
 RDKit Postgres Cartridge Example
 ********************************
+
+This example demonstrates how to use the RDKit cartridge with a PostgreSQL database.
+When using the RDKit Postgres container, you can launch the container then access the database server using the `psql` command line tool 
+from the host machine or from within the container.
+
+Launching the RDKit Postgres Container
+--------------------------------------  
+
+You can launch the server using the following command. 
+Note that you should replace `mysecretpassword` with a password of your choice.
+
+.. code-block:: bash
+
+    docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d molssi/rdkitpostgres-postgres162:latest
+
+
+This will start the server. 
+You can access it from within the container using the following command.
+
+.. code-block:: bash
+
+    docker exec -it rdkitpostgres psql -U postgres
+
+Because the command set up port mapping (`-p 5432:5432`), you can also access the server from the host machine using the following command.
+Note that you will need to have the `psql` command line tool installed on your host machine and enter the password you specified when launching the container.
+
+.. code-block:: bash
+
+    psql -h localhost -U postgres -d postgres
+
+
+Loading Data
+------------
+
+For a more detailed tutorial, please refer to the `RDKit PostgreSQL cartridge documentation <https://www.rdkit.org/docs/Cartridge.html>`_
+
+The following example demonstrates how to load data into the database.
+
+First, make sure the RDKit extension is loaded:
+
+.. code-block:: sql 
+
+    CREATE EXTENSION IF NOT EXISTS rdkit;
+
+
+Next, create a table called `mols` with a `mol` column.
+
+.. code-block:: sql 
+
+    CREATE TABLE mols (id serial primary key, mol mol);
+
+
+Next, load a few molecules into the database using SMILES strings:
+
+.. code-block:: sql 
+
+    INSERT INTO mols (mol) VALUES ('c1ccccc1');
+    INSERT INTO mols (mol) VALUES ('CCO');
+    INSERT INTO mols (mol) VALUES ('CC(=O)O');
+    INSERT INTO mols (mol) VALUES ('C(=O)CC');
+
+
+Querying Data
+--------------
+
+You can now perform queries like substring searches, similarity searches, and other analysis associated with RDKit.
+For example, to find all molecules that contain a carbonyl group, you can use the following query.
+
+.. code-block:: sql 
+    
+    SELECT * FROM mols WHERE mol @> 'C(=O)';
+  
+
+
+
+
+

--- a/docs/compchem/rdkitpostgres-example.rst
+++ b/docs/compchem/rdkitpostgres-example.rst
@@ -1,0 +1,5 @@
+.. _rdkitpostgres_example:
+
+********************************
+RDKit Postgres Cartridge Example
+********************************

--- a/molssi_hub/compchem/rdkit-postgres162/Dockerfile
+++ b/molssi_hub/compchem/rdkit-postgres162/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:16.2
+
+LABEL maintainer="Jessica A. Nash, \
+                  Molecular Sciences Software Institute"
+
+RUN apt update && \
+    apt install -y --no-install-recommends postgresql-16-rdkit && \
+    rm -rf /var/lib/apt/lists/*

--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -12,8 +12,8 @@
         {
             "Repository": "",
             "Tags": "",
-            "Source":"",
-            "Recipe":""
+            "Source":"https://github.com/MolSSI/molssi-hub/tree/main/molssi_hub/compchem/rdkit-postgres162",
+            "Recipe":"https://github.com/MolSSI/molssi-hub/blob/main/molssi_hub/compchem/rdkit-postgres162/Dockerfile"
         }
     ],
     "docker_pull_command": "docker pull molssi/rdkitpostgres-postgres162:latest",

--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -1,0 +1,45 @@
+{
+    "name": "RDKit Postgres Cartridge",
+    "description": "RDKit PostgreSQL cartridge is a PostgreSQL extension that provides chemical structure handling functionality to the PostgreSQL database. It is based on the RDKit cheminformatics library.",
+    "source_specifications": [
+        {
+            "Developers": "",
+            "Source": "https://github.com/rdkit/rdkit",
+            "Documentation": "https://www.rdkit.org/docs/index.html"
+        }
+    ],
+    "hub_specifications": [
+        {
+            "Repository": "",
+            "Tags": "",
+            "Source":"",
+            "Recipe":""
+        }
+    ],
+    "docker_pull_command": "docker pull molssi/rdkit-postgres:latest",
+    "docker_run_command": "docker run -it --name rdkit-postgres -v $(pwd):/home rdkit-postgres:latest /bin/bash",
+    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "image_specifications":[
+        {
+            "OS/Arch": "debian:bookworm-slim",
+            "Users (UID)": "root (0)",
+            "Groups (GID)": "root (0)",
+            "Environment variables": [
+                {
+                    "POSTGRES_PASSWORD": "",
+                    "POSTGRES_USER": "postgres",
+                    "POSTGRES_DB": "postgres"
+
+                }
+            ],
+            "Volumes": "None",
+            "Network": "None",
+            "Extras": [
+                {
+                    "Added directories": "None",
+                    "Important packages installed": ""
+                }
+            ]
+        }
+    ]
+}

--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -17,8 +17,9 @@
         }
     ],
     "docker_pull_command": "docker pull molssi/rdkitpostgres-postgres162:latest",
-    "docker_run_command": "docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -d molssi/rdkitpostgres-postgres162:latest",
+    "docker_run_command": "docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d molssi/rdkitpostgres-postgres162:latest",
     "note": "See the full documentation for the base PostgreSQL image for alternative environment variables and run commands - https://hub.docker.com/_/postgres",
+    "tip": "See the full documentation for the base PostgreSQL image for alternative environment variables and run commands - https://hub.docker.com/_/postgres",
     "image_specifications":[
         {
             "OS/Arch": "debian:bookworm-slim",

--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -10,8 +10,8 @@
     ],
     "hub_specifications": [
         {
-            "Repository": "",
-            "Tags": "",
+            "Repository": "https://hub.docker.com/r/molssi/rdkit-postgres162",
+            "Tags": "https://hub.docker.com/r/molssi/rdkit-postgres162/tags",
             "Source":"https://github.com/MolSSI/molssi-hub/tree/main/molssi_hub/compchem/rdkit-postgres162",
             "Recipe":"https://github.com/MolSSI/molssi-hub/blob/main/molssi_hub/compchem/rdkit-postgres162/Dockerfile"
         }

--- a/molssi_hub/compchem/rdkit-postgres162/metadata.json
+++ b/molssi_hub/compchem/rdkit-postgres162/metadata.json
@@ -3,9 +3,9 @@
     "description": "RDKit PostgreSQL cartridge is a PostgreSQL extension that provides chemical structure handling functionality to the PostgreSQL database. It is based on the RDKit cheminformatics library.",
     "source_specifications": [
         {
-            "Developers": "",
+            "Developers": "https://github.com/rdkit/rdkit/graphs/contributors",
             "Source": "https://github.com/rdkit/rdkit",
-            "Documentation": "https://www.rdkit.org/docs/index.html"
+            "Documentation": "https://www.rdkit.org/docs/Cartridge.html"
         }
     ],
     "hub_specifications": [
@@ -16,9 +16,9 @@
             "Recipe":""
         }
     ],
-    "docker_pull_command": "docker pull molssi/rdkit-postgres:latest",
-    "docker_run_command": "docker run -it --name rdkit-postgres -v $(pwd):/home rdkit-postgres:latest /bin/bash",
-    "note": "By default, the ``-v $(pwd):/home`` option mounts the current working directory to ``/home`` in your running container. Doing so, the contents of your current working directory become available in your running container. If you do not wish this to happen, you may simply remove or change this option.",
+    "docker_pull_command": "docker pull molssi/rdkitpostgres-postgres162:latest",
+    "docker_run_command": "docker run --name rdkitpostgres -e POSTGRES_PASSWORD=mysecretpassword -d molssi/rdkitpostgres-postgres162:latest",
+    "note": "See the full documentation for the base PostgreSQL image for alternative environment variables and run commands - https://hub.docker.com/_/postgres",
     "image_specifications":[
         {
             "OS/Arch": "debian:bookworm-slim",


### PR DESCRIPTION
This PR is currently a draft.

This PR adds a Dockerfile and associated metadata for a Docker image with postgres and the RDKit Postgres cartridge. 

It uses a standard Postgres image as the base, and installs the RDKit cartridge to allow use with databases with chemical data.

**Questions**
This image is fairly simple. I'm unsure of how to fill out some of the metadata, particularly the image specifications. The documentation for postgres (https://hub.docker.com/_/postgres) covers most of this. Should the image specifications, etc only cover new functionality for an image?